### PR TITLE
chore: optim workflow

### DIFF
--- a/.github/workflows/publish_whl.yml
+++ b/.github/workflows/publish_whl.yml
@@ -34,6 +34,7 @@ jobs:
 
           pip install -r requirements.txt
           pip install rapidocr_onnxruntime
+          pip install pytest
           pytest tests/test_table.py
 
   GenerateWHL_PushPyPi:
@@ -52,6 +53,8 @@ jobs:
       - name: Run setup
         run: |
           pip install -r requirements.txt
+          python -m pip install --upgrade pip
+          pip install wheel get_pypi_latest_version
           wget $RESOURCES_URL
           ZIP_NAME=${RESOURCES_URL##*/}
           DIR_NAME=${ZIP_NAME%.*}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@ opencv_python>=4.5.1.48
 numpy>=1.21.6,<2
 Pillow
 requests
-pytest
-get_pypi_latest_version


### PR DESCRIPTION
将pytest和get_pypi_latest_version安装放到workflow配置里，避免requirement污染