### PR TITLE
修复_load_imgs中isinstance(img_content,InputType)错误

### DIFF
--- a/rapid_table/main.py
+++ b/rapid_table/main.py
@@ -121,9 +121,7 @@ class RapidTable:
     def _load_imgs(
         self, img_content: Union[Sequence[InputType], InputType]
     ) -> List[np.ndarray]:
-        img_contents = (
-            [img_content] if isinstance(img_content, InputType) else img_content
-        )
+        img_contents = img_content if isinstance(img_content, list) else [img_content]
         return [self.load_img(img) for img in img_contents]
 
     def get_ocr_results(

--- a/rapid_table/main.py
+++ b/rapid_table/main.py
@@ -5,7 +5,7 @@ import argparse
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, get_args
 
 import numpy as np
 from tqdm import tqdm
@@ -74,6 +74,16 @@ class RapidTable:
     ) -> RapidTableOutput:
         if not isinstance(img_contents, list):
             img_contents = [img_contents]
+
+        for img_content in img_contents:
+            if not isinstance(img_content, get_args(InputType)):
+                type_names = ", ".join([t.__name__ for t in get_args(InputType)])
+                actual_type = (
+                    type(img_content).__name__ if img_content is not None else "None"
+                )
+                raise TypeError(
+                    f"Type Error: Expected input of type [{type_names}], but received '{img_content}' of type {actual_type}."
+                )
 
         s = time.perf_counter()
 


### PR DESCRIPTION
原来的代码,判断类型会报错 TypeError: Subscripted generics cannot be used with class and instance checks
```python
img_contents = (
       [img_content] if isinstance(img_content, InputType) else img_content
)
```
修复如下:
1. 对传入的类型先统一判断,如果类型不符合要求就提前抛出异常
2. _load_imgs仅判断是否list,否则就组装为list
